### PR TITLE
Use official supported way to install oVirt repositories

### DIFF
--- a/.automation/prepare-env-cs8.sh
+++ b/.automation/prepare-env-cs8.sh
@@ -1,13 +1,10 @@
 #!/bin/bash -xe
 
-# TODO: Replace with ovirt-release-master RPM installation
-REPO_FILE="/etc/yum.repos.d/virt8s-ovirt-45-el8s.repo"
-printf "[ovirt-master-centos-stream-ovirt45-testing]\n" > ${REPO_FILE}
-printf "name=CentOS Stream 8 - oVirt 4.5 - testing\n" >> ${REPO_FILE}
-printf "baseurl=https://buildlogs.centos.org/centos/8-stream/virt/x86_64/ovirt-45/\n" >> ${REPO_FILE}
-printf "gpgcheck=0\n" >> ${REPO_FILE}
-printf "enabled=1\n" >> ${REPO_FILE}
-printf "module_hotfixes=1" >> ${REPO_FILE}
+# Install oVirt repositories
+rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
+dnf install -y \
+    --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/ \
+    ovirt-release-master
 
 # Install required packages
 dnf config-manager --enable powertools

--- a/.automation/prepare-env-cs9.sh
+++ b/.automation/prepare-env-cs9.sh
@@ -1,16 +1,13 @@
 #!/bin/bash -xe
 
-# TODO: Replace with ovirt-release-master RPM installation
-REPO_FILE="/etc/yum.repos.d/virt8s-ovirt-45-el9s.repo"
-printf "[ovirt-master-centos-stream-ovirt45-testing]\n" > ${REPO_FILE}
-printf "name=CentOS Stream 9 - oVirt 4.5 - testing\n" >> ${REPO_FILE}
-printf "baseurl=https://buildlogs.centos.org/centos/9-stream/virt/x86_64/ovirt-45/\n" >> ${REPO_FILE}
-printf "gpgcheck=0\n" >> ${REPO_FILE}
-printf "enabled=1\n" >> ${REPO_FILE}
-printf "module_hotfixes=1" >> ${REPO_FILE}
+# DNF core plugins are installed in the official CS9 container image
+dnf install -y dnf-plugins-core
+
+# Install oVirt repositories
+dnf copr enable -y ovirt/ovirt-master-snapshot
+yum install -y ovirt-release-master
 
 # Install required packages
-dnf install -y dnf-plugins-core
 dnf config-manager --enable crb
 dnf install -y \
     createrepo_c \


### PR DESCRIPTION
Use official supported way to install oVirt repositories as described in
https://ovirt.org/develop/dev-process/install-nightly-snapshot.html

Signed-off-by: Martin Perina <mperina@redhat.com>