### PR TITLE
Fix maven cache directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,10 +73,10 @@ jobs:
     - name: Use cache for maven
       uses: actions/cache@v2
       with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        path: /root/.m2/repository
+        key: ${{ matrix.shortcut }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ matrix.shortcut }}-maven-
 
     - name: Perform build
       run: |


### PR DESCRIPTION
Set maven cache directory to `/root/.m2` because we are using container
based builds and processes within a container runs under root use, but
github sets $HOME  to a different directory and maven still uses /root
as a home directory

Signed-off-by: Martin Perina <mperina@redhat.com>
